### PR TITLE
Add an invisible ref to the official French mastodon account

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -8,6 +8,7 @@
   <link rel="shortcut icon" type="image/png" href="/img/logo.png">
   <link rel="shortcut icon" sizes="192x192" href="/img/logo.png">
   <link rel="apple-touch-icon" href="/img/logo.png">
+  <link rel="me" href="https://piaille.fr/@NopeFoundry">
   {{ with .OutputFormats.Get "rss" -}}
     {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
   {{ end -}}


### PR DESCRIPTION
This is useful to get the verified status on the link.

Note: this is already in production